### PR TITLE
Avoid CMP0048 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ cmake_minimum_required (VERSION 2.8)
 option(BUILD_SHARED_LIBS "Build shared library." OFF)
 option(BUILD_TESTING "Build tests." OFF)
 
+if (POLICY CMP0048)
+  # cmake warns if fmem is included from a parent directory whose CMakeLists.txt
+  # requires a CMake version of 3.0 or later
+  cmake_policy(SET CMP0048 NEW)
+endif()
+
 project (fmem C)
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.cmake")


### PR DESCRIPTION
Problem:
- When `fmem`'s `CMakeLists.txt` gets included from a parent project via
  an `include_directory` where the parent has a CMake min version of 3.0
  requirement, the `fmem` `project()` call results in a CMP0048 warning.

Solution:
- If the CMake policy 0048 is available (i.e. if CMake 3.0 or later is
  used), set the policy to `NEW`.
- This results in the warning going away for parent projects using CMake
  3.0 or later. This has no effect on those using earlier versions of
  CMake.