### PR TITLE
Added CMake option for BUILD_TESTING which defaults to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,7 @@ install(TARGETS fmem
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(FILES
-  fmem.h
-  ${PROJECT_BINARY_DIR}/gen/fmem-export.h
+  ${PROJECT_BINARY_DIR}/gen/fmem.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 include (CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required (VERSION 2.8)
 
 project (fmem C)
 
+OPTION(BUILD_TESTING "Build the tests with ON, defaults to OFF" OFF)
+
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.cmake")
 
 include (CheckSymbolExists)
@@ -74,8 +76,8 @@ else ()
   message (FATAL_ERROR "No memory stream implementation found")
 endif ()
 
-include_directories (include src ${PROJECT_BINARY_DIR}/gen)
 add_library (fmem ${SOURCES})
+target_include_directories (fmem PUBLIC ${PROJECT_BINARY_DIR}/gen)
 
 get_property (FMEM_LIBTYPE
   TARGET fmem


### PR DESCRIPTION
I've added an BUILD_TESTING because the default value was always TRUE (or ON) and thus it failed for me lots.

For the include_directories it only makes sense to use the 'gen' folder since include is basically empty and src doesn't make sense either. Not sure with src though since there is a alloc.h but to me it seems to be something internal.